### PR TITLE
match new savePredictions return in caret

### DIFF
--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -167,7 +167,7 @@ extractModelTypes <- function(list_of_models){
 #' @importFrom data.table data.table setorderv
 bestPreds <- function(x){
   stopifnot(is(x, "train"))
-  stopifnot(x$control$savePredictions)
+  stopifnot(x$control$savePredictions != "none")
   a <- data.table(x$bestTune, key=names(x$bestTune))
   b <- data.table(x$pred, key=names(x$bestTune))
   b <- b[a,]


### PR DESCRIPTION
The return value of `x$control$savePredictions` is no longer boolean; now the check needs to not be `!= none`. I believe this closes zachmayer/caretEnsemble#178. 
